### PR TITLE
FE | Add e2e tests for trunk based metrics.

### DIFF
--- a/Client/src/components/containers/TrunkBasedMetricsContainers/TrunkBasedMetricsTiles/TrunkBasedMetricsTiles.tsx
+++ b/Client/src/components/containers/TrunkBasedMetricsContainers/TrunkBasedMetricsTiles/TrunkBasedMetricsTiles.tsx
@@ -57,7 +57,7 @@ export const TrunkBasedMetricsTiles = () => {
             size="16px"
           />
           <div className={styles.tileInfo}>
-            <div>
+            <div data-testid="total-branches">
               {totalNumberOfBranches ? totalNumberOfBranches : NOT_AVAILABLE}
             </div>
             <NavLink to={branchesURL} target="blank" className={styles.navLink}>
@@ -74,7 +74,7 @@ export const TrunkBasedMetricsTiles = () => {
             size="16px"
           />
           <div className={styles.tileInfo}>
-            <div>
+            <div data-testid="active-branches">
               {activeBranchesList.length
                 ? activeBranchesList.length
                 : NOT_AVAILABLE}
@@ -103,7 +103,9 @@ export const TrunkBasedMetricsTiles = () => {
             size="16px"
           />
           <div className={styles.tileInfo}>
-            <div>{percentageOfBranchesFollowingStandard}</div>
+            <div data-testid="branches-following-naming-standard">
+              {percentageOfBranchesFollowingStandard}
+            </div>
             <div
               className={styles.icon}
               onClick={() => setIsBranchesNamingConventionDialogOpen(true)}

--- a/Client/src/components/containers/TrunkBasedMetricsContainers/TrunkBasedPullRequestsTable/TrunkBasedPullRequestsTable.tsx
+++ b/Client/src/components/containers/TrunkBasedMetricsContainers/TrunkBasedPullRequestsTable/TrunkBasedPullRequestsTable.tsx
@@ -88,6 +88,7 @@ export const TrunkBasedPullRequestsTable = ({ startDate, endDate }: Props) => {
                   {columns.map((column) => (
                     <TableCell
                       key={column.id}
+                      data-testid={`${column.id}-table-header`}
                       align={column.align}
                       style={{ width: column.width }}
                     >
@@ -112,6 +113,7 @@ export const TrunkBasedPullRequestsTable = ({ startDate, endDate }: Props) => {
 
                     return (
                       <TableRow
+                        data-testid="trunk-based-metrics-table-row"
                         role="checkbox"
                         tabIndex={-1}
                         className={isEvenRow ? styles.rowEven : styles.rowOdd}
@@ -184,7 +186,9 @@ export const TrunkBasedPullRequestsTable = ({ startDate, endDate }: Props) => {
                 size="16px"
               />
               <div>
-                <span>{searchedActiveBranches.length}</span>
+                <span data-testid="total-pull-requests">
+                  {searchedActiveBranches.length}
+                </span>
               </div>
             </div>
           </Tile>
@@ -197,7 +201,7 @@ export const TrunkBasedPullRequestsTable = ({ startDate, endDate }: Props) => {
                 size="16px"
               />
               <div>
-                <span>
+                <span data-testid="merged-branches-percentage">
                   {getMergedPullRequest(searchedActiveBranches).percentage}
                 </span>
               </div>

--- a/Client/src/components/containers/TrunkBasedMetricsContainers/TrunkBasedPullRequestsTable/trunkBasedPullRequestsTableUtils.tsx
+++ b/Client/src/components/containers/TrunkBasedMetricsContainers/TrunkBasedPullRequestsTable/trunkBasedPullRequestsTableUtils.tsx
@@ -55,7 +55,7 @@ export function getMergedPullRequest(
       ? `${(
           (mergedPRsCount / pullRequests.length) *
           BASE_PERCENTAGE
-        ).toFixed()} %`
-      : "0 %",
+        ).toFixed()}%`
+      : "0%",
   };
 }

--- a/Client/tests/endToEnd/codeReviewMetrics/code-review.test.ts
+++ b/Client/tests/endToEnd/codeReviewMetrics/code-review.test.ts
@@ -2,6 +2,7 @@ import "dotenv/config";
 import { test, expect, Page } from "@playwright/test";
 
 import { pathToCodeReviewMetrics } from "../../../src/constants/routeConstants";
+import { TIMEOUT_PERIOD, WAIT_UNTIL } from "../constants/commonConstants";
 
 const codeReviewEndPoint = `${process.env.CLIENT_DEV_URL}${pathToCodeReviewMetrics}`;
 
@@ -13,7 +14,11 @@ test.describe("Code Review Metrics page", () => {
 
     page = await context.newPage();
 
-    await page.goto(codeReviewEndPoint);
+    await page.goto(codeReviewEndPoint, {
+      waitUntil: WAIT_UNTIL,
+      timeout: TIMEOUT_PERIOD,
+    });
+
     await page.waitForSelector("table");
   });
 

--- a/Client/tests/endToEnd/constants/commonConstants.ts
+++ b/Client/tests/endToEnd/constants/commonConstants.ts
@@ -1,0 +1,2 @@
+export const TIMEOUT_PERIOD = 20000;
+export const WAIT_UNTIL = "load";

--- a/Client/tests/endToEnd/trunkBasedMetrics/trunk-based.test.ts
+++ b/Client/tests/endToEnd/trunkBasedMetrics/trunk-based.test.ts
@@ -1,0 +1,107 @@
+import "dotenv/config";
+import { test, expect, Page } from "@playwright/test";
+
+import { pathToTrunkBasedMetrics } from "../../../src/constants/routeConstants";
+import { TIMEOUT_PERIOD, WAIT_UNTIL } from "../constants/commonConstants";
+
+const trunkBasedMetricsEndPoint = `${process.env.CLIENT_DEV_URL}${pathToTrunkBasedMetrics}`;
+
+test.describe("Trunk Based Metrics page", () => {
+  let page: Page;
+
+  test.beforeAll(async ({ browser }) => {
+    const context = await browser.newContext();
+
+    page = await context.newPage();
+
+    await page.goto(trunkBasedMetricsEndPoint, {
+      waitUntil: WAIT_UNTIL,
+      timeout: TIMEOUT_PERIOD,
+    });
+    await page.waitForSelector("table");
+  });
+
+  test('should display heading "Trunk Based Metrics"', async () => {
+    const element = await page.locator("text=Trunk Based Metrics").isVisible();
+
+    expect(element).toBeTruthy();
+  });
+
+  test("should display required tiles with text for trunk based metrics", async () => {
+    await page.goto(trunkBasedMetricsEndPoint);
+
+    const selectors = [
+      "text=Total no of branches",
+      "text=Active PR's to trunk branch",
+      "text=Branches following naming standard",
+      "text=Total Pull Requests",
+      "text=Percentage of branches merged",
+    ];
+
+    await Promise.all(
+      selectors.map(async (selector) => {
+        const element = await page.waitForSelector(selector, {
+          state: "visible",
+        });
+        const isVisible = await element.isVisible();
+
+        expect(isVisible).toBeTruthy();
+      }),
+    );
+  });
+
+  test("should display tiles with number for trunk based metrics", async () => {
+    const selectors = [
+      "[data-testid='total-branches']",
+      "[data-testid='active-branches']",
+      "[data-testid='total-pull-requests']",
+    ];
+
+    const regex = /^[0-9]+$/;
+
+    for (const selector of selectors) {
+      const textContent = await page.locator(selector).textContent();
+
+      expect(textContent).toMatch(regex);
+    }
+  });
+
+  test("should display titles with number and percentage for trunk based metrics", async () => {
+    const selectors = [
+      "[data-testid='branches-following-naming-standard']",
+      "[data-testid='merged-branches-percentage']",
+    ];
+
+    const regex = /^[0-9]+(\.[0-9]+)?%$/;
+
+    for (const selector of selectors) {
+      const textContent = await page.locator(selector).textContent();
+
+      expect(textContent).toMatch(regex);
+    }
+  });
+
+  test("should display table in trunk based metrics", async () => {
+    const table = await page.$("table");
+
+    expect(table).toBeTruthy();
+  });
+
+  test("should display column headers in the trunk based table", async () => {
+    const selectors = ["name", "title", "creationDate", "closedDate", "status"];
+
+    for (const selector of selectors) {
+      const element = await page
+        .locator(`[data-testid="${selector}-table-header"]`)
+        .isVisible();
+
+      expect(element).toBeTruthy();
+    }
+  });
+
+  test("should display rows in the trunk based table", async () => {
+    const rows = await page.$$("[data-testid='trunk-based-metrics-table-row']");
+
+    expect(rows.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
# Why this change is required

This PR aims to add tests for trunk based metrics.

# Describe your changes

- added e2e tests for trunk based development page.
- added constants for page timeout & wait until.
- removed space between percentage in trunk-based tiles.
- added data-testid tags.

# How this change has been tested

Tested using playwright.

# Reference

![image](https://github.com/solitontech/Software-Practices-Metrics-tool/assets/127190944/8beb27a9-1c7f-48aa-b903-96e4e43a4e1f)
![image](https://github.com/solitontech/Software-Practices-Metrics-tool/assets/127190944/a79515fb-3b1d-4826-8f7f-49a4aa02166f)


# Checklist

- [x] I have performed a self review of my code and intend to submit as such
- [ ] I have added necessary explanations and inline comments for review
- [ ] I have considered updating necessary README or other documentations
- [x] I have added/modified necessary automated tests
- [ ] This includes a breaking changes and needs to be listed in release notes
