### PR TITLE
FE | Remove webkit & Firefox from playwright tests.

### DIFF
--- a/Client/playwright.config.ts
+++ b/Client/playwright.config.ts
@@ -37,15 +37,15 @@ export default defineConfig({
       use: { ...devices["Desktop Chrome"] },
     },
 
-    {
-      name: "firefox",
-      use: { ...devices["Desktop Firefox"] },
-    },
+    // {
+    //   name: "firefox",
+    //   use: { ...devices["Desktop Firefox"] },
+    // },
 
-    {
-      name: "webkit",
-      use: { ...devices["Desktop Safari"] },
-    },
+    // {
+    //   name: "webkit",
+    //   use: { ...devices["Desktop Safari"] },
+    // },
 
     /* Test against mobile viewports. */
     // {


### PR DESCRIPTION
# Why this change is required

This PR aims to resolve timeout errors in the E2E tests.

# Describe your changes

- removed testing for webkit & firefox.

# How this change has been tested

Tested in playwright.

# Reference

![image](https://github.com/solitontech/Software-Practices-Metrics-tool/assets/127190944/52acaf4c-610b-4ed2-8b25-96b96d8bcdd3)
![image](https://github.com/solitontech/Software-Practices-Metrics-tool/assets/127190944/da80b10b-f5af-4905-bd1a-7c3fb1b874e2)


# Checklist

- [x] I have performed a self review of my code and intend to submit as such
- [ ] I have added necessary explanations and inline comments for review
- [ ] I have considered updating necessary README or other documentations
- [x] I have added/modified necessary automated tests
- [ ] This includes a breaking changes and needs to be listed in release notes
