### PR TITLE
Add server process level error handler

### DIFF
--- a/Server/package.json
+++ b/Server/package.json
@@ -2,10 +2,10 @@
   "name": "software-practices-metrics-tool",
   "version": "1.0.0",
   "description": "This tool will be useful to measure the metrics for different software practices",
-  "main": "app.js",
+  "main": "index.js",
   "scripts": {
-    "start:prod": "NODE_ENVIRONMENT=production node src/app.js",
-    "start:dev": "set NODE_ENVIRONMENT=development&& nodemon src/app.js",
+    "start:prod": "NODE_ENVIRONMENT=production node src/index.js",
+    "start:dev": "set NODE_ENVIRONMENT=development&& nodemon src/index.js",
     "test": "set NODE_ENVIRONMENT=test&& node --experimental-vm-modules node_modules/jest/bin/jest.js --coverage",
     "test-ci": "NODE_ENVIRONMENT=test node --experimental-vm-modules node_modules/jest/bin/jest.js --coverage",
     "format": "prettier --write \"**/*.{js,json}\" && npx markdownlint-cli \"**/*.md\"",

--- a/Server/src/app.js
+++ b/Server/src/app.js
@@ -11,7 +11,7 @@ import { NODE_ENVIRONMENT_MODE, STATUS_CODE } from './constants/index.js';
 const dirName = path.dirname(fileURLToPath(import.meta.url));
 const app = express();
 
-const { nodeEnvironment, port, clientDevelopmentUrlOrigin, swaggerEditorUrlOrigin } =
+const { nodeEnvironment, clientDevelopmentUrlOrigin, swaggerEditorUrlOrigin } =
   ServerConfiguration.environmentVariables;
 
 if (nodeEnvironment === NODE_ENVIRONMENT_MODE.DEVELOPMENT) {
@@ -48,11 +48,5 @@ app.get('*', (req, res) => {
 
 // express global error handler for api routes
 app.use(globalErrorHandlerMiddleware);
-
-if (nodeEnvironment !== NODE_ENVIRONMENT_MODE.TEST) {
-  app.listen(port, () => {
-    console.log('Server is running on port:', port);
-  });
-}
 
 export default app;

--- a/Server/src/index.js
+++ b/Server/src/index.js
@@ -1,0 +1,13 @@
+import app from './app.js';
+
+import { ServerConfiguration } from './configs/server.config.js';
+import { logError } from './utils/logger.js';
+
+const { port } = ServerConfiguration.environmentVariables;
+
+process.on('uncaughtException', logError);
+process.on('unhandledRejection', logError);
+
+app.listen(port, () => {
+  console.log('Server is running on port:', port);
+});


### PR DESCRIPTION
# Why this change is required

Add process level error handler for uncaught error and promise rejection error

# Describe your changes

By default when these errors occur the node js server will terminate, by adding this error listener we can gracefully log the error without crashing the server

# How this change has been tested

Tested Manually

# Reference

NA

# Checklist

- [ ] I have performed a self review of my code and intend to submit as such
- [ ] I have added necessary explanations and inline comments for review
- [ ] I have considered updating necessary README or other documentations
- [ ] I have added/modified necessary automated tests
- [ ] This includes a breaking changes and needs to be listed in release notes
