### PR TITLE
FE | Remove 'as' type conversions in metrics graph reusable.

### DIFF
--- a/client/src/components/reusables/MetricsGraphs/BarChart/BarChart.tsx
+++ b/client/src/components/reusables/MetricsGraphs/BarChart/BarChart.tsx
@@ -1,4 +1,4 @@
-import { Config, Data, Layout, ModeBarDefaultButtons } from "plotly.js";
+import { Config, Data, Layout } from "plotly.js";
 import Plot from "react-plotly.js";
 
 import { EMPTY_STRING, TAB_SPACE } from "./barChartConstants";
@@ -9,15 +9,14 @@ interface IBarChartProps {
   graph: IBarChart;
 }
 
-//TODO: remove enum and use constants to avoid typescript "as" conversion
 export const BarChart = ({
   graph: {
     plots,
     graphTitle = "",
     xAxisName = "",
     yAxisName = "",
-    graphHeight = GRAPH.HEIGHT as number,
-    graphWidth = GRAPH.WIDTH as number,
+    graphHeight = GRAPH.HEIGHT,
+    graphWidth = GRAPH.WIDTH,
     fileNameForImage = "bar-chart",
     graphAnnotationText,
     barMode = "group",
@@ -38,7 +37,7 @@ export const BarChart = ({
       hoverinfo: GRAPH.HOVER_INFO,
       hoverlabel: {
         align: GRAPH.HOVER_ALIGN,
-        bgcolor: GRAPH.TOOL_TIP_BACKGROUND_COLOR as string,
+        bgcolor: GRAPH.TOOL_TIP_BACKGROUND_COLOR,
       },
       name: plot.plotName,
     };
@@ -49,8 +48,8 @@ export const BarChart = ({
       text: graphTitle,
       xref: ANNOTATIONS.AXIS_REFERENCE,
       yref: ANNOTATIONS.AXIS_REFERENCE,
-      x: ANNOTATIONS.X_POSITION as number,
-      y: ANNOTATIONS.Y_POSITION as number,
+      x: ANNOTATIONS.X_POSITION,
+      y: ANNOTATIONS.Y_POSITION,
     },
     xaxis: {
       title: xAxisName,
@@ -66,7 +65,7 @@ export const BarChart = ({
     width: graphWidth,
     height: graphHeight,
     font: {
-      family: GRAPH.FONT_FAMILY as string,
+      family: GRAPH.FONT_FAMILY,
     },
     annotations: [
       {
@@ -76,11 +75,11 @@ export const BarChart = ({
         yref: ANNOTATIONS.AXIS_REFERENCE,
         text: graphAnnotationText,
         showarrow: false,
-        bordercolor: ANNOTATIONS.BORDER_COLOR as string,
-        borderwidth: ANNOTATIONS.BORDER_WIDTH as number,
-        borderpad: ANNOTATIONS.BORDER_PAD as number,
+        bordercolor: ANNOTATIONS.BORDER_COLOR,
+        borderwidth: ANNOTATIONS.BORDER_WIDTH,
+        borderpad: ANNOTATIONS.BORDER_PAD,
         font: {
-          size: ANNOTATIONS.FONT_SIZE as number,
+          size: ANNOTATIONS.FONT_SIZE,
         },
       },
     ],
@@ -93,7 +92,7 @@ export const BarChart = ({
     toImageButtonOptions: {
       filename: fileNameForImage,
     },
-    modeBarButtonsToRemove: GRAPH_MODE_BAR_BUTTONS_TO_REMOVE as ModeBarDefaultButtons[],
+    modeBarButtonsToRemove: GRAPH_MODE_BAR_BUTTONS_TO_REMOVE,
     scrollZoom: true,
   };
 

--- a/client/src/components/reusables/MetricsGraphs/Histogram/Histogram.tsx
+++ b/client/src/components/reusables/MetricsGraphs/Histogram/Histogram.tsx
@@ -1,4 +1,4 @@
-import { Config, Data, Layout, ModeBarDefaultButtons } from "plotly.js";
+import { Config, Data, Layout } from "plotly.js";
 import Plot from "react-plotly.js";
 
 import { IHistogramChart } from "./histogramTypes";
@@ -8,15 +8,14 @@ interface IHistogramChartProps {
   graph: IHistogramChart;
 }
 
-//TODO: remove enum and use constants to avoid typescript "as" conversion
 export const HistogramChart = ({
   graph: {
     plot: { xValues, startValue, endValue, binSize, binText, markerColor, hoverText },
     xAxisName = "",
     yAxisName = "",
     graphTitle = "",
-    graphWidth = GRAPH.WIDTH as number,
-    graphHeight = GRAPH.HEIGHT as number,
+    graphWidth = GRAPH.WIDTH,
+    graphHeight = GRAPH.HEIGHT,
     graphAnnotationText,
     fileNameForImage = "histogram-chart",
   },
@@ -38,7 +37,7 @@ export const HistogramChart = ({
       hoverinfo: GRAPH.HOVER_INFO,
       hoverlabel: {
         align: GRAPH.HOVER_ALIGN,
-        bgcolor: GRAPH.TOOL_TIP_BACKGROUND_COLOR as string,
+        bgcolor: GRAPH.TOOL_TIP_BACKGROUND_COLOR,
       },
     },
   ];
@@ -61,18 +60,18 @@ export const HistogramChart = ({
         yref: ANNOTATIONS.AXIS_REFERENCE,
         text: graphAnnotationText,
         showarrow: false,
-        bordercolor: ANNOTATIONS.BORDER_COLOR as string,
-        borderwidth: ANNOTATIONS.BORDER_WIDTH as number,
-        borderpad: ANNOTATIONS.BORDER_PAD as number,
+        bordercolor: ANNOTATIONS.BORDER_COLOR,
+        borderwidth: ANNOTATIONS.BORDER_WIDTH,
+        borderpad: ANNOTATIONS.BORDER_PAD,
         font: {
-          size: ANNOTATIONS.FONT_SIZE as number,
+          size: ANNOTATIONS.FONT_SIZE,
         },
       },
     ],
     width: graphWidth,
     height: graphHeight,
     font: {
-      family: GRAPH.FONT_FAMILY as string,
+      family: GRAPH.FONT_FAMILY,
     },
     dragmode: GRAPH.DRAG_MODE,
   };
@@ -83,7 +82,7 @@ export const HistogramChart = ({
       filename: fileNameForImage,
     },
     editable: false,
-    modeBarButtonsToRemove: GRAPH_MODE_BAR_BUTTONS_TO_REMOVE as ModeBarDefaultButtons[],
+    modeBarButtonsToRemove: GRAPH_MODE_BAR_BUTTONS_TO_REMOVE,
     scrollZoom: true,
   };
 

--- a/client/src/components/reusables/MetricsGraphs/PieChart/PieChart.tsx
+++ b/client/src/components/reusables/MetricsGraphs/PieChart/PieChart.tsx
@@ -8,14 +8,13 @@ interface IPieChartProps {
   graph: IPieChart;
 }
 
-//TODO: remove enum and use constants to avoid typescript "as" conversion
 export const PieChart = ({
   graph: {
     plots,
     totalValue,
     graphTitle = "",
-    graphHeight = GRAPH.HEIGHT as number,
-    graphWidth = GRAPH.WIDTH as number,
+    graphHeight = GRAPH.HEIGHT,
+    graphWidth = GRAPH.WIDTH,
     fileNameForImage = "pie-chart",
     graphAnnotationText,
     annotationYPosition = ANNOTATIONS.Y_POSITION,
@@ -51,7 +50,7 @@ export const PieChart = ({
       hoverinfo: GRAPH.HOVER_INFO,
       hoverlabel: {
         align: GRAPH.HOVER_ALIGN,
-        bgcolor: GRAPH.TOOL_TIP_BACKGROUND_COLOR as string,
+        bgcolor: GRAPH.TOOL_TIP_BACKGROUND_COLOR,
       },
     },
   ];
@@ -61,13 +60,13 @@ export const PieChart = ({
       text: graphTitle,
       xref: ANNOTATIONS.AXIS_REFERENCE,
       yref: ANNOTATIONS.AXIS_REFERENCE,
-      x: ANNOTATIONS.X_POSITION as number,
-      y: ANNOTATIONS.Y_POSITION as number,
+      x: ANNOTATIONS.X_POSITION,
+      y: ANNOTATIONS.Y_POSITION,
     },
     width: graphWidth,
     height: graphHeight,
     font: {
-      family: GRAPH.FONT_FAMILY as string,
+      family: GRAPH.FONT_FAMILY,
     },
     annotations: [
       {
@@ -77,11 +76,11 @@ export const PieChart = ({
         yref: ANNOTATIONS.AXIS_REFERENCE,
         text: graphAnnotationText,
         showarrow: false,
-        bordercolor: ANNOTATIONS.BORDER_COLOR as string,
-        borderwidth: ANNOTATIONS.BORDER_WIDTH as number,
-        borderpad: ANNOTATIONS.BORDER_PAD as number,
+        bordercolor: ANNOTATIONS.BORDER_COLOR,
+        borderwidth: ANNOTATIONS.BORDER_WIDTH,
+        borderpad: ANNOTATIONS.BORDER_PAD,
         font: {
-          size: ANNOTATIONS.FONT_SIZE as number,
+          size: ANNOTATIONS.FONT_SIZE,
         },
       },
     ],

--- a/client/src/components/reusables/MetricsGraphs/metricsGraphConstants.ts
+++ b/client/src/components/reusables/MetricsGraphs/metricsGraphConstants.ts
@@ -1,22 +1,29 @@
-export const GRAPH_MODE_BAR_BUTTONS_TO_REMOVE = ["lasso2d", "select2d", "autoScale2d", "zoom2d"];
+import { ModeBarDefaultButtons } from "plotly.js";
 
-export enum GRAPH {
-  HOVER_INFO = "text",
-  FONT_FAMILY = "Roboto",
-  HOVER_ALIGN = "left",
-  AXIS_RANGE_MODE = "nonnegative",
-  WIDTH = 1100,
-  HEIGHT = 550,
-  TOOL_TIP_BACKGROUND_COLOR = "#4f5355",
-  DRAG_MODE = "pan",
-}
+export const GRAPH_MODE_BAR_BUTTONS_TO_REMOVE: ModeBarDefaultButtons[] = [
+  "lasso2d",
+  "select2d",
+  "autoScale2d",
+  "zoom2d",
+];
 
-export enum ANNOTATIONS {
-  X_POSITION = 0.5,
-  Y_POSITION = 1.09,
-  AXIS_REFERENCE = "paper",
-  BORDER_COLOR = "#000000",
-  BORDER_WIDTH = 2,
-  BORDER_PAD = 6,
-  FONT_SIZE = 14,
-}
+export const GRAPH = Object.freeze({
+  HOVER_INFO: "text",
+  FONT_FAMILY: "Roboto",
+  HOVER_ALIGN: "left",
+  AXIS_RANGE_MODE: "nonnegative",
+  WIDTH: 1100,
+  HEIGHT: 550,
+  TOOL_TIP_BACKGROUND_COLOR: "#4f5355",
+  DRAG_MODE: "pan",
+});
+
+export const ANNOTATIONS = Object.freeze({
+  X_POSITION: 0.5,
+  Y_POSITION: 1.09,
+  AXIS_REFERENCE: "paper",
+  BORDER_COLOR: "#000000",
+  BORDER_WIDTH: 2,
+  BORDER_PAD: 6,
+  FONT_SIZE: 14,
+});


### PR DESCRIPTION
# Why this change is required

This PR aims to remove 'as' type conversions in metrics graph reusable.

# Describe your changes

Converted Enums into constant objects.

# How this change has been tested

NA

# Reference

NA

# Checklist

- [x] I have performed a self review of my code and intend to submit as such
- [ ] I have added necessary explanations and inline comments for review
- [ ] I have considered updating necessary README or other documentations
- [ ] I have added/modified necessary automated tests
- [ ] This includes a breaking changes and needs to be listed in release notes
