### PR TITLE
FE | Resolve console errors.

### DIFF
--- a/client/src/components/reusables/Tile/Tile.tsx
+++ b/client/src/components/reusables/Tile/Tile.tsx
@@ -9,7 +9,7 @@ export const Tile = ({ title, children }: ITileProps) => {
   return (
     <div className={styles.tile}>
       <h6 className={styles.title}>{title}</h6>
-      <p className={styles.children}>{children}</p>
+      {children}
     </div>
   );
 };


### PR DESCRIPTION
# Why this change is required

There were console errors due to nesting of `<p>` & '<div>` tags under `<p>` tag. This PR aims to resolve the issue.

# Describe your changes

- removed `<p>` tag to nest children in Tile reusable.

# How this change has been tested

Tested in browser

# Reference

![download (21)](https://github.com/solitontech/Software-Practices-Metrics-tool/assets/127190944/a50989c6-309c-47c4-a500-44a7de52f2a0)


# Checklist

- [x] I have performed a self review of my code and intend to submit as such
- [ ] I have added necessary explanations and inline comments for review
- [ ] I have considered updating necessary README or other documentations
- [ ] I have added/modified necessary automated tests
- [ ] This includes a breaking changes and needs to be listed in release notes
