### PR TITLE
FE | Rename variable sortMap to SORT_MAP.

### DIFF
--- a/client/src/components/containers/CodeReviewMetricsContainers/CodeReviewMetricsTable/codeReviewMetricsTableConstants.ts
+++ b/client/src/components/containers/CodeReviewMetricsContainers/CodeReviewMetricsTable/codeReviewMetricsTableConstants.ts
@@ -1,15 +1,15 @@
 import { CodeReviewSortingIcon } from "src/components/components";
-import { VOTES, sortMap } from "src/constants/constants";
+import { VOTES, SORT_MAP } from "src/constants/constants";
 import { IFetchedPullRequestVotes } from "src/services/api/api";
 
 import { ICodeReviewTableColumn, ICodeReviewTableVotesFilterColumn } from "./codeReviewMetricsTableTypes";
 import { CodeReviewTableVotesFilter } from "./CodeReviewTableVotesFilter/CodeReviewTableVotesFilter";
 
 export const DEFAULT_SORT_STATE = {
-  comments: sortMap.noSort,
-  firstReviewResponseTimeInSeconds: sortMap.noSort,
-  approvalTimeInSeconds: sortMap.noSort,
-  mergeTimeInSeconds: sortMap.noSort,
+  comments: SORT_MAP.NO_SORT,
+  firstReviewResponseTimeInSeconds: SORT_MAP.NO_SORT,
+  approvalTimeInSeconds: SORT_MAP.NO_SORT,
+  mergeTimeInSeconds: SORT_MAP.NO_SORT,
 };
 
 const VOTES_FILTER_DEFAULT_STATE: Record<keyof IFetchedPullRequestVotes, boolean> = {

--- a/client/src/components/containers/CodeReviewMetricsContainers/CodeReviewMetricsTable/codeReviewMetricsTableUtils.tsx
+++ b/client/src/components/containers/CodeReviewMetricsContainers/CodeReviewMetricsTable/codeReviewMetricsTableUtils.tsx
@@ -1,4 +1,4 @@
-import { sortMap } from "src/constants/constants";
+import { SORT_MAP } from "src/constants/constants";
 import { IFetchedCodeReviewPullRequest, IFetchedPullRequestVotes } from "src/services/api/api";
 
 import { ICodeReviewTableVotesFilterColumn } from "./codeReviewMetricsTableTypes";
@@ -9,7 +9,7 @@ export class CodeReviewMetricsTableUtil {
     return pullRequests.sort(
       (firstPullRequest: IFetchedCodeReviewPullRequest, secondPullRequest: IFetchedCodeReviewPullRequest) => {
         for (const key in sort) {
-          if (sort[key] === sortMap.noSort) continue;
+          if (sort[key] === SORT_MAP.NO_SORT) continue;
 
           let firstValue = firstPullRequest[key as keyof IFetchedCodeReviewPullRequest];
           let secondValue = secondPullRequest[key as keyof IFetchedCodeReviewPullRequest];
@@ -38,7 +38,7 @@ export class CodeReviewMetricsTableUtil {
             secondValue = secondPullRequest.comments.totalComments;
           }
 
-          if (sort[key] === sortMap.asc) {
+          if (sort[key] === SORT_MAP.ASCENDING) {
             if (firstValue < secondValue) {
               return 1;
             }
@@ -48,7 +48,7 @@ export class CodeReviewMetricsTableUtil {
             }
           }
 
-          if (sort[key] === sortMap.desc) {
+          if (sort[key] === SORT_MAP.DESCENDING) {
             if (firstValue === null) {
               return 1;
             }

--- a/client/src/components/containers/CodeReviewMetricsContainers/CodeReviewSortingIcon/CodeReviewSortingIcon.tsx
+++ b/client/src/components/containers/CodeReviewMetricsContainers/CodeReviewSortingIcon/CodeReviewSortingIcon.tsx
@@ -2,7 +2,7 @@ import ExpandLessIcon from "@mui/icons-material/ExpandLess";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import { Tooltip } from "@mui/material";
 
-import { sortMap } from "src/constants/constants";
+import { SORT_MAP } from "src/constants/constants";
 
 import styles from "./CodeReviewSortingIcon.module.scss";
 
@@ -17,7 +17,7 @@ export const CodeReviewSortingIcon = ({ handleSort }: ICodeReviewSortingIconProp
         <ExpandLessIcon
           className={styles.sortButton}
           onClick={() => {
-            handleSort(sortMap.asc);
+            handleSort(SORT_MAP.ASCENDING);
           }}
         />
       </Tooltip>
@@ -25,7 +25,7 @@ export const CodeReviewSortingIcon = ({ handleSort }: ICodeReviewSortingIconProp
         <ExpandMoreIcon
           className={styles.sortButton}
           onClick={() => {
-            handleSort(sortMap.desc);
+            handleSort(SORT_MAP.DESCENDING);
           }}
         />
       </Tooltip>

--- a/client/src/constants/codeReviewMetrics.constants.ts
+++ b/client/src/constants/codeReviewMetrics.constants.ts
@@ -22,9 +22,8 @@ export const VOTES_COLOR = {
   NO_VOTE: "#d9d9d9",
 };
 
-//TODO: Rename to caps
-export const sortMap = {
-  asc: "asc",
-  desc: "desc",
-  noSort: " noSort",
+export const SORT_MAP = {
+  ASCENDING: "asc",
+  DESCENDING: "desc",
+  NO_SORT: " noSort",
 };


### PR DESCRIPTION
# Why this change is required

This PR aims to capitalize the variable sortMap 

# Describe your changes

- change all references of sortMap to SORT_MAP.

# How this change has been tested

Tested in browser.

# Reference
![download (28)](https://github.com/solitontech/Software-Practices-Metrics-tool/assets/127190944/a9c2218f-6a1b-4594-b88a-6fa862ada064)



# Checklist

- [x] I have performed a self review of my code and intend to submit as such
- [ ] I have added necessary explanations and inline comments for review
- [ ] I have considered updating necessary README or other documentations
- [ ] I have added/modified necessary automated tests
- [ ] This includes a breaking changes and needs to be listed in release notes
