### PR TITLE
style: align reviewers to right in client filters.

### DIFF
--- a/client/src/components/containers/ClientFilters/ClientFilters.module.scss
+++ b/client/src/components/containers/ClientFilters/ClientFilters.module.scss
@@ -54,10 +54,11 @@
 
 .categoryContainer {
   display: flex;
+  justify-content: space-between;
 }
 
 .memberContainer {
-  width: 50%;
+  width: 47.5%;
 }
 
 .squadCategory {
@@ -70,6 +71,7 @@
 
 .userContainer {
   padding: 0 $spacing-lg;
+  padding-right: 0;
 }
 
 .userLabel {


### PR DESCRIPTION
# Why this change is required

This PR aims to align reviewers to right in client filters.

# Describe your changes

- modified the alignment

# How this change has been tested

Tested the UI in browser

# Reference

![image](https://github.com/solitontech/software-practices-metrics-tool/assets/127190944/1f80b30f-9c22-4878-9377-9f2650359f24)


# Checklist

- [x] I have performed a self review of my code and intend to submit as such
- [ ] I have added necessary explanations and inline comments for review
- [ ] I have considered updating necessary README or other documentations
- [ ] I have added/modified necessary automated tests
- [ ] This includes a breaking changes and needs to be listed in release notes
