### PR TITLE
fix: display only developers when reviewers are not configured.

### DIFF
--- a/client/src/components/containers/ClientFilters/ClientFilters.tsx
+++ b/client/src/components/containers/ClientFilters/ClientFilters.tsx
@@ -74,7 +74,9 @@ const MemberFilters = () => {
             </h4>
             <div className={styles.categoryContainer}>
               {category.map(({ key, label, members }) => {
-                const hasAllMembersSelected = Object.values(members).every(({ isSelected }) => isSelected);
+                const hasAllMembersSelected = members.length
+                  ? Object.values(members).every(({ isSelected }) => isSelected)
+                  : false;
 
                 return (
                   <div key={label} className={styles.memberContainer}>

--- a/client/src/services/api/hooks/clientFilters/clientFiltersUtils.ts
+++ b/client/src/services/api/hooks/clientFilters/clientFiltersUtils.ts
@@ -1,7 +1,12 @@
 import { IFetchedClientFilterResponse, IFetchedClientFilterSquadMember } from "./clientFiltersTypes";
 
 export class ClientFiltersUtils {
-  static #getUsers(usersRecord: Record<string, string>, isSelected: boolean): IFetchedClientFilterSquadMember[] {
+  static #getUsers(
+    usersRecord: Record<string, string> | undefined,
+    isSelected: boolean,
+  ): IFetchedClientFilterSquadMember[] {
+    if (!usersRecord) return [];
+
     return Object.entries(usersRecord).map(([id, name]) => {
       return {
         id,


### PR DESCRIPTION
# Why this change is required

Currently when developers are configured but reviewers are not configured, developers are not displayed in client filters. This PR aims to fix the bug.

# Describe your changes

- make reviewers optional in client code based.

# How this change has been tested

Tested UI in browser.

# Reference

![image](https://github.com/solitontech/software-practices-metrics-tool/assets/127190944/5ed1446d-cb24-4710-8537-fb8b2e653a85)

# Checklist

- [x] I have performed a self review of my code and intend to submit as such
- [ ] I have added necessary explanations and inline comments for review
- [ ] I have considered updating necessary README or other documentations
- [ ] I have added/modified necessary automated tests
- [ ] This includes a breaking changes and needs to be listed in release notes
